### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 A Model Context Protocol (MCP) server that provides real-time flight tracking and status information using the AviationStack API.
 
+<a href="https://glama.ai/mcp/servers/@Cyreslab-AI/flightradar-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Cyreslab-AI/flightradar-mcp-server/badge" alt="FlightRadar Server MCP server" />
+</a>
+
 ## Features
 
 This MCP server provides three main tools:


### PR DESCRIPTION
This PR adds a badge for the [FlightRadar MCP Server](https://glama.ai/mcp/servers/@Cyreslab-AI/flightradar-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@Cyreslab-AI/flightradar-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Cyreslab-AI/flightradar-mcp-server/badge" alt="FlightRadar Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.